### PR TITLE
Update build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies += "com.github.scopt" %% "scopt" % "3.2.0"
 
 libraryDependencies += "org.apache.spark" %% "spark-core" % "0.9.1" % "provided"
 
-libraryDependencies += "com.datastax.spark" %% "spark-cassandra-connector" % "1.0.0-beta2"
+libraryDependencies += "com.datastax.spark" %% "spark-cassandra-connector" % "1.0.0"
 
 resolvers += Resolver.sonatypeRepo("public")
 


### PR DESCRIPTION
spark-cassandra-connector released stable R1.0.0. Updated the build.sbt to use the GA version.
